### PR TITLE
Minor changes to error handling when fetching posts & media

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,4 +37,6 @@ pub enum GertError {
     FfmpegError(String),
     #[error("Error unzipping file")]
     ZipError(#[from] zip::result::ZipError),
+    #[error("Media has been removed from imgur")]
+    ImgurRemovedError,
 }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -254,7 +254,11 @@ impl Post {
             }
         }
         if url.contains(REDDIT_VIDEO_SUBDOMAIN) {
-            return MediaType::RedditVideo;
+            if self.data.media.is_none() {
+               return MediaType::Unsupported 
+            } else {
+                return MediaType::RedditVideo;
+            }
         }
 
         if  url.contains(REDGIFS_DOMAIN) {


### PR DESCRIPTION
Hey @mcdallas 

Just wanted to propose a few changes for some issues I ran into :)

- handle error when attempting to get posts for sub if data can't be found: 
  - Gert would panic without indicating which sub couldn't be fetched. If trying to get multiple subs, gert will now print an error and move onto the next
- handle error when post has no media data, common with crossposts mainly. 
  - These would also panic when trying to unwrap media
- Prevent gert from downloading imgur media when that media has been removed/deleted
  - Especially common on older subs a lot of media has been removed so gert downloads and saves the ["removed image"](https://i.imgur.com/removed.png), this just skips the saving of those files.